### PR TITLE
Removed unnecessary math.Pow calls

### DIFF
--- a/cauchy.go
+++ b/cauchy.go
@@ -67,7 +67,8 @@ func (dist Cauchy) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
     return 0.0, err
   }
-  denom := math.Pow(x - dist.Location, 2) + math.Pow(dist.Scale, 2)
+  diff := x - dist.Location
+  denom := (diff * diff) + (dist.Scale * dist.Scale)
   result := dist.Scale / denom / math.Pi
   return result, nil
 }

--- a/gamma.go
+++ b/gamma.go
@@ -36,7 +36,7 @@ func (dist Gamma) Variance() (float64, error) {
   if err := dist.validate(); err != nil {
     return 0.0, err
   }
-  result := dist.Shape / math.Pow(dist.Rate, 2)
+  result := dist.Shape / (dist.Rate * dist.Rate)
   return result, nil
 }
 
@@ -60,7 +60,7 @@ func (dist Gamma) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
     return 0.0, err
   }
-  result := math.Sqrt(dist.Shape / math.Pow(dist.Rate, 2))
+  result := math.Sqrt(dist.Shape / (dist.Rate * dist.Rate))
   return result, nil
 }
 
@@ -135,12 +135,12 @@ func (dist Gamma) random() (float64, error) {
       x = random
       v = 1 + (c * x)
     }
-    v = math.Pow(v, 3)
+    v = v * v * v
     u := rand.Float64()
-    if u < 1 - 0.331 * math.Pow(x, 4) {
+    if u < 1 - 0.331 * x * x * x * x {
       break
     }
-    if math.Log(u) < (0.5 * math.Pow(x, 2)) + d * (1 - v + math.Log(v)) {
+    if math.Log(u) < (0.5 * x * x) + d * (1 - v + math.Log(v)) {
       break
     }
   }

--- a/normal.go
+++ b/normal.go
@@ -73,7 +73,8 @@ func (dist Normal) Pdf(x float64) (float64, error) {
   if err != nil {
     return 0.0, err
   }
-  expo := -1 * math.Pow(x - dist.Mu, 2) / (2 * variance)
+  diff := x - dist.Mu
+  expo := -1 * diff * diff / (2 * variance)
   denom := math.Sqrt(2 * variance * math.Pi)
   result := math.Exp(expo) / denom
   return result, nil

--- a/pareto.go
+++ b/pareto.go
@@ -42,7 +42,7 @@ func (dist Pareto) Variance() (float64, error) {
   if (dist.Shape <= 2.0) {
     return math.Inf(1), nil
   }
-  result := (dist.Shape * math.Pow(dist.Scale, 2)) / (math.Pow(dist.Shape - 1, 2) * (dist.Shape - 2))
+  result := (dist.Shape * dist.Scale * dist.Scale) / ((dist.Shape - 1) * (dist.Shape - 1) * (dist.Shape - 2))
   return result, nil
 }
 
@@ -64,7 +64,7 @@ func (dist Pareto) Kurtosis() (float64, error) {
   if (dist.Shape < 3.0) {
     return math.NaN(), IndeterminateError
   }
-  result := 6 * (math.Pow(dist.Shape, 3) + math.Pow(dist.Shape,2) - (6 * (dist.Shape - 2))) / (dist.Shape * (dist.Shape - 3) * (dist.Shape - 4))
+  result := 6 * ((dist.Shape * dist.Shape * dist.Shape) + (dist.Shape * dist.Shape) - (6 * (dist.Shape - 2))) / (dist.Shape * (dist.Shape - 3) * (dist.Shape - 4))
   return result, nil
 }
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -55,7 +55,7 @@ func checkNaN(f1, f2 float64) bool {
   if math.IsNaN(f1) || math.IsNaN(f2) {
    return math.IsNaN(f1) && math.IsNaN(f2)
   }
-  return true 
+  return true
 }
 
 func averageFloats(values []float64) float64 {
@@ -67,9 +67,10 @@ func averageFloats(values []float64) float64 {
 }
 
 func varianceFloats(values []float64, mean float64) float64 {
-  var total float64
+  var total, diff float64
   for _, value := range values {
-    total += math.Pow(value - mean, 2)
+    diff = value - mean
+    total += diff * diff
   }
   return total / (float64(len(values)) - 1)
 }

--- a/uniform.go
+++ b/uniform.go
@@ -33,7 +33,8 @@ func (dist Uniform) Variance() (float64, error) {
   if err := dist.validate(); err != nil {
     return 0.0, err
   }
-  result := math.Pow(dist.Max - dist.Min, 2) / 12
+  diff := dist.Max - dist.Min
+  result := diff * diff / 12
   return result, nil
 }
 
@@ -55,7 +56,8 @@ func (dist Uniform) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
     return 0.0, err
   }
-  result := math.Sqrt(math.Pow(dist.Max - dist.Min, 2) / 12)
+  diff := dist.Max - dist.Min
+  result := math.Sqrt(diff * diff / 12)
   return result, nil
 }
 


### PR DESCRIPTION
Removed `math.Pow` calls that had integer exponents. This should make things a little faster.

See:  #10