### PR TITLE
Replaced IndeterminateErrors and values

### DIFF
--- a/cauchy.go
+++ b/cauchy.go
@@ -23,49 +23,49 @@ func (dist Cauchy) validate() error {
 
 func (dist Cauchy) Mean() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
-  return 0.0, IndeterminateError
+  return math.NaN(), nil
 }
 
 func (dist Cauchy) Variance() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
-  return 0.0, IndeterminateError
+  return math.NaN(), nil
 }
 
 func (dist Cauchy) Skewness() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
-  return 0.0, IndeterminateError
+  return math.NaN(), nil
 }
 
 func (dist Cauchy) Kurtosis() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
-  return 0.0, IndeterminateError
+  return math.NaN(), nil
 }
 
 func (dist Cauchy) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
-  return 0.0, IndeterminateError
+  return math.NaN(), nil
 }
 
 func (dist Cauchy) RelStdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
-  return 0.0, IndeterminateError
+  return math.NaN(), nil
 }
 
 func (dist Cauchy) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   diff := x - dist.Location
   denom := (diff * diff) + (dist.Scale * dist.Scale)
@@ -75,7 +75,7 @@ func (dist Cauchy) Pdf(x float64) (float64, error) {
 
 func (dist Cauchy) Cdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := (math.Atan((x - dist.Location) / dist.Scale) / math.Pi) + 0.5
   return result, nil
@@ -83,7 +83,7 @@ func (dist Cauchy) Cdf(x float64) (float64, error) {
 
 func (dist Cauchy) random() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   var u float64
   for u == 0.0 || u == 0.5 {

--- a/cauchy_test.go
+++ b/cauchy_test.go
@@ -1,18 +1,19 @@
 package distributions
 
 import (
+  "math"
   "testing"
 )
 
 type cauchyTest struct {
   magnitude   float64
   dist        Distribution
-  mean        error
-  variance    error
-  stdDev      error
-  relStdDev   error
-  skewness    error
-  kurtosis    error
+  mean        float64
+  variance    float64
+  stdDev      float64
+  relStdDev   float64
+  skewness    float64
+  kurtosis    float64
   pdf         []inOut
   cdf         []inOut
 }
@@ -22,12 +23,12 @@ func Test_Cauchy(t *testing.T) {
   examples := []cauchyTest{
     cauchyTest{
       dist:       Cauchy{10.0, 2.0},
-      mean:       IndeterminateError,
-      variance:   IndeterminateError,
-      stdDev:     IndeterminateError,
-      relStdDev:  IndeterminateError,
-      skewness:   IndeterminateError,
-      kurtosis:   IndeterminateError,
+      mean:       math.NaN(),
+      variance:   math.NaN(),
+      stdDev:     math.NaN(),
+      relStdDev:  math.NaN(),
+      skewness:   math.NaN(),
+      kurtosis:   math.NaN(),
       pdf: []inOut{
         inOut{ in: 4.0,   out: 0.01591549430918953357689 },
         inOut{ in: 6.0,   out: 0.03183098861837906715378 },
@@ -41,12 +42,12 @@ func Test_Cauchy(t *testing.T) {
     },
     cauchyTest{
       dist:       Cauchy{1.0, 4.0},
-      mean:       IndeterminateError,
-      variance:   IndeterminateError,
-      stdDev:     IndeterminateError,
-      relStdDev:  IndeterminateError,
-      skewness:   IndeterminateError,
-      kurtosis:   IndeterminateError,
+      mean:       math.NaN(),
+      variance:   math.NaN(),
+      stdDev:     math.NaN(),
+      relStdDev:  math.NaN(),
+      skewness:   math.NaN(),
+      kurtosis:   math.NaN(),
       pdf: []inOut{
         inOut{ in: 2.0,   out: 0.07489644380795074624418 },
         inOut{ in: 0.5,   out: 0.07835320275293308837853 },
@@ -62,28 +63,40 @@ func Test_Cauchy(t *testing.T) {
 
   for _, example := range examples {
     mean, err := example.dist.Mean()
-    if err == nil || err != example.mean {
-      t.Fatalf("\nMean:\n  Expected: %f\n  Got: %f\n", example.mean, mean)
+    if err != nil || !floatsPicoEqual(mean, example.mean) {
+      if !checkInf(mean, example.mean) && !checkNaN(mean, example.mean) {
+        t.Fatalf("\nMean:\n  Expected: %f\n  Got: %f\n", example.mean, mean)
+      }
     }
     variance, err := example.dist.Variance()
-    if err == nil || err != example.variance {
-      t.Fatalf("\nVariance:\n  Expected: %f\n  Got: %f\n", example.variance, variance)
+    if err != nil || !floatsPicoEqual(variance, example.variance) {
+      if !checkInf(variance, example.variance) && !checkNaN(variance, example.variance) {
+        t.Fatalf("\nVariance:\n  Expected: %f\n  Got: %f\n", example.variance, variance)
+      }
     }
     stdDev, err := example.dist.StdDev()
-    if err == nil || err != example.stdDev {
-      t.Fatalf("\nStdDev:\n  Expected: %f\n  Got: %f\n", example.stdDev, stdDev)
+    if err != nil || !floatsPicoEqual(stdDev, example.stdDev) {
+      if !checkInf(stdDev, example.stdDev) && !checkNaN(stdDev, example.stdDev) {
+        t.Fatalf("\nStdDev:\n  Expected: %f\n  Got: %f\n", example.stdDev, stdDev)
+      }
     }
     relStdDev, err := example.dist.RelStdDev()
-    if err == nil || err != example.relStdDev {
-      t.Fatalf("\nRelStdDev:\n  Expected: %f\n  Got: %f\n", example.relStdDev, relStdDev)
+    if err != nil || !floatsPicoEqual(relStdDev, example.relStdDev) {
+      if !checkInf(relStdDev, example.relStdDev) && !checkNaN(relStdDev, example.relStdDev) {
+        t.Fatalf("\nRelStdDev:\n  Expected: %f\n  Got: %f\n", example.relStdDev, relStdDev)
+      }
     }
     skewness, err := example.dist.Skewness()
-    if err == nil || err != example.skewness {
-      t.Fatalf("\nSkewness:\n  Expected: %f\n  Got: %f\n", example.skewness, skewness)
+    if err != nil || !floatsPicoEqual(skewness, example.skewness) {
+      if !checkInf(skewness, example.skewness) && !checkNaN(skewness, example.skewness) {
+        t.Fatalf("\nSkewness:\n  Expected: %f\n  Got: %f\n", example.skewness, skewness)
+      }
     }
     kurtosis, err := example.dist.Kurtosis()
-    if err == nil || err != example.kurtosis {
-      t.Fatalf("\nKurtosis:\n  Expected: %f\n  Got: %f\n", example.kurtosis, kurtosis)
+    if err != nil || !floatsPicoEqual(kurtosis, example.kurtosis) {
+      if !checkInf(kurtosis, example.kurtosis) && !checkNaN(kurtosis, example.kurtosis) {
+        t.Fatalf("\nKurtosis:\n  Expected: %f\n  Got: %f\n", example.kurtosis, kurtosis)
+      }
     }
     for _, pdf := range example.pdf {
       out, err := example.dist.Pdf(pdf.in)

--- a/errors.go
+++ b/errors.go
@@ -1,11 +1,6 @@
 package distributions
 
-import "errors"
-
 // Signifies bad parameters for a distribution.
 type InvalidParamsError struct{ S string }
-
-// Signifies an undefined result. Eg. When the variance is undefined.
-var IndeterminateError = errors.New("Iindeterminate value. Result is NaN.")
 
 func (e InvalidParamsError) Error() string { return e.S }

--- a/exponential.go
+++ b/exponential.go
@@ -22,14 +22,14 @@ func (dist Exponential) validate() error {
 
 func (dist Exponential) Mean() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return dist.Lambda, nil
 }
 
 func (dist Exponential) Variance() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := dist.Lambda * dist.Lambda
   return result, nil
@@ -37,35 +37,35 @@ func (dist Exponential) Variance() (float64, error) {
 
 func (dist Exponential) Skewness() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return 2.0, nil
 }
 
 func (dist Exponential) Kurtosis() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return 9.0, nil
 }
 
 func (dist Exponential) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return dist.Lambda, nil
 }
 
 func (dist Exponential) RelStdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return 1.0, nil
 }
 
 func (dist Exponential) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if x < 0 {
     return 0.0, nil
@@ -76,7 +76,7 @@ func (dist Exponential) Pdf(x float64) (float64, error) {
 
 func (dist Exponential) Cdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if (x <= 0) {
     return 0.0, nil
@@ -87,7 +87,7 @@ func (dist Exponential) Cdf(x float64) (float64, error) {
 
 func (dist Exponential) random() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   value := -1 * dist.Lambda * math.Log1p(-1 * rand.Float64())
   return value, nil

--- a/gamma.go
+++ b/gamma.go
@@ -26,7 +26,7 @@ func (dist Gamma) validate() error {
 
 func (dist Gamma) Mean() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := dist.Shape / dist.Rate
   return result, nil
@@ -34,7 +34,7 @@ func (dist Gamma) Mean() (float64, error) {
 
 func (dist Gamma) Variance() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := dist.Shape / (dist.Rate * dist.Rate)
   return result, nil
@@ -42,7 +42,7 @@ func (dist Gamma) Variance() (float64, error) {
 
 func (dist Gamma) Skewness() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := 2 / math.Sqrt(dist.Shape)
   return result, nil
@@ -50,7 +50,7 @@ func (dist Gamma) Skewness() (float64, error) {
 
 func (dist Gamma) Kurtosis() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := 6 / dist.Shape
   return result, nil
@@ -58,7 +58,7 @@ func (dist Gamma) Kurtosis() (float64, error) {
 
 func (dist Gamma) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := math.Sqrt(dist.Shape / (dist.Rate * dist.Rate))
   return result, nil
@@ -66,7 +66,7 @@ func (dist Gamma) StdDev() (float64, error) {
 
 func (dist Gamma) RelStdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := 1 / math.Sqrt(dist.Shape)
   return result, nil
@@ -74,7 +74,7 @@ func (dist Gamma) RelStdDev() (float64, error) {
 
 func (dist Gamma) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if x < 0 {
     return 0.0, nil
@@ -96,7 +96,7 @@ func (dist Gamma) Pdf(x float64) (float64, error) {
 
 func (dist Gamma) Cdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if (x <= 0) {
     return 0.0, nil
@@ -107,18 +107,18 @@ func (dist Gamma) Cdf(x float64) (float64, error) {
 
 func (dist Gamma) random() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if (dist.Shape < 1) {
     random := rand.Float64()
     newDist := Gamma{ Shape: dist.Shape + 1, Rate: dist.Rate }
     grandom, err := newDist.random()
     if err != nil {
-      return 0.0, err
+      return math.NaN(), err
     }
     result := grandom * math.Pow(random, 1 / dist.Shape)
     if err != nil {
-      return 0.0, err
+      return math.NaN(), err
     }
     return result, nil
   }
@@ -130,7 +130,7 @@ func (dist Gamma) random() (float64, error) {
     for ok := true; ok; ok = v <= 0 {
       random, _, err := normal.random()
       if err != nil {
-        return 0.0, err
+        return math.NaN(), err
       }
       x = random
       v = 1 + (c * x)

--- a/normal.go
+++ b/normal.go
@@ -23,14 +23,14 @@ func (dist Normal) validate() error {
 
 func (dist Normal) Mean() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return dist.Mu, nil
 }
 
 func (dist Normal) Variance() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := dist.Sigma * dist.Sigma
   return result, nil
@@ -38,28 +38,28 @@ func (dist Normal) Variance() (float64, error) {
 
 func (dist Normal) Skewness() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return 0.0, nil
 }
 
 func (dist Normal) Kurtosis() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return 3.0, nil
 }
 
 func (dist Normal) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return dist.Sigma, nil
 }
 
 func (dist Normal) RelStdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := dist.Sigma / dist.Mu
   return result, nil
@@ -67,11 +67,11 @@ func (dist Normal) RelStdDev() (float64, error) {
 
 func (dist Normal) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   variance, err := dist.Variance()
   if err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   diff := x - dist.Mu
   expo := -1 * diff * diff / (2 * variance)
@@ -82,7 +82,7 @@ func (dist Normal) Pdf(x float64) (float64, error) {
 
 func (dist Normal) Cdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   inner := 1 + math.Erf( (x - dist.Mu) / (dist.Sigma * math.Sqrt(2)) )
   result := math.Abs(inner) / 2;
@@ -91,7 +91,7 @@ func (dist Normal) Cdf(x float64) (float64, error) {
 
 func (dist Normal) random() (float64, float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, 0.0, err
+    return math.NaN(), math.NaN(), err
   }
   a := rand.Float64() * 2 * math.Pi
   b := math.Sqrt(-2.0 * math.Log(1.0 - rand.Float64()))

--- a/pareto.go
+++ b/pareto.go
@@ -51,7 +51,7 @@ func (dist Pareto) Skewness() (float64, error) {
     return math.NaN(), err
   }
   if (dist.Shape < 3.0) {
-    return math.NaN(), IndeterminateError
+    return math.NaN(), nil
   }
   result := 2 * (1 + dist.Shape) / (dist.Shape - 3) * math.Sqrt((dist.Shape - 2) / dist.Shape)
   return result, nil
@@ -62,7 +62,7 @@ func (dist Pareto) Kurtosis() (float64, error) {
     return math.NaN(), err
   }
   if (dist.Shape < 3.0) {
-    return math.NaN(), IndeterminateError
+    return math.NaN(), nil
   }
   result := 6 * ((dist.Shape * dist.Shape * dist.Shape) + (dist.Shape * dist.Shape) - (6 * (dist.Shape - 2))) / (dist.Shape * (dist.Shape - 3) * (dist.Shape - 4))
   return result, nil
@@ -70,7 +70,7 @@ func (dist Pareto) Kurtosis() (float64, error) {
 
 func (dist Pareto) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   variance, _ := dist.Variance()
   if math.IsInf(variance, 0) {
@@ -82,7 +82,7 @@ func (dist Pareto) StdDev() (float64, error) {
 
 func (dist Pareto) RelStdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   variance, _ := dist.Variance()
   if math.IsInf(variance, 0) {
@@ -98,7 +98,7 @@ func (dist Pareto) RelStdDev() (float64, error) {
 
 func (dist Pareto) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if x < dist.Scale {
     return 0.0, nil
@@ -109,7 +109,7 @@ func (dist Pareto) Pdf(x float64) (float64, error) {
 
 func (dist Pareto) Cdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if (x < dist.Scale) {
     return 0.0, nil
@@ -120,7 +120,7 @@ func (dist Pareto) Cdf(x float64) (float64, error) {
 
 func (dist Pareto) random() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   value := dist.Scale / math.Pow(1 - rand.Float64(), 1 / dist.Shape)
   return value, nil

--- a/uniform.go
+++ b/uniform.go
@@ -23,7 +23,7 @@ func (dist Uniform) validate() error {
 
 func (dist Uniform) Mean() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := (dist.Min + dist.Max) / 2
   return result, nil
@@ -31,7 +31,7 @@ func (dist Uniform) Mean() (float64, error) {
 
 func (dist Uniform) Variance() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   diff := dist.Max - dist.Min
   result := diff * diff / 12
@@ -40,21 +40,21 @@ func (dist Uniform) Variance() (float64, error) {
 
 func (dist Uniform) Skewness() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return 0.0, nil
 }
 
 func (dist Uniform) Kurtosis() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   return -6.0 / 5.0, nil
 }
 
 func (dist Uniform) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   diff := dist.Max - dist.Min
   result := math.Sqrt(diff * diff / 12)
@@ -63,7 +63,7 @@ func (dist Uniform) StdDev() (float64, error) {
 
 func (dist Uniform) RelStdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   result := (dist.Max - dist.Min) / (math.Sqrt(3) * (dist.Max + dist.Min))
   return result, nil
@@ -71,7 +71,7 @@ func (dist Uniform) RelStdDev() (float64, error) {
 
 func (dist Uniform) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if x < dist.Min || x > dist.Max {
     return 0.0, nil
@@ -82,7 +82,7 @@ func (dist Uniform) Pdf(x float64) (float64, error) {
 
 func (dist Uniform) Cdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if (x < dist.Min) {
     return 0.0, nil
@@ -96,7 +96,7 @@ func (dist Uniform) Cdf(x float64) (float64, error) {
 
 func (dist Uniform) random() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   value := dist.Min + (rand.Float64() * (dist.Max - dist.Min))
   return value, nil

--- a/weibull.go
+++ b/weibull.go
@@ -70,7 +70,7 @@ func (dist Weibull) Kurtosis() (float64, error) {
 
 func (dist Weibull) StdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   variance, _ := dist.Variance()
   result := math.Sqrt(variance)
@@ -79,7 +79,7 @@ func (dist Weibull) StdDev() (float64, error) {
 
 func (dist Weibull) RelStdDev() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   variance, _ := dist.Variance()
   mean, _ := dist.Mean()
@@ -89,7 +89,7 @@ func (dist Weibull) RelStdDev() (float64, error) {
 
 func (dist Weibull) Pdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if x < 0.0 {
     return 0.0, nil
@@ -100,7 +100,7 @@ func (dist Weibull) Pdf(x float64) (float64, error) {
 
 func (dist Weibull) Cdf(x float64) (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   if (x < 0.0) {
     return 0.0, nil
@@ -111,7 +111,7 @@ func (dist Weibull) Cdf(x float64) (float64, error) {
 
 func (dist Weibull) random() (float64, error) {
   if err := dist.validate(); err != nil {
-    return 0.0, err
+    return math.NaN(), err
   }
   value := dist.Scale * math.Pow(-math.Log(rand.Float64()), 1 / dist.Shape)
   return value, nil


### PR DESCRIPTION
The `InderterminateError` has been removed. Also, `math.NaN()` is returned when an error occurs to more correctly reflect that the value is not valid.

See: #11